### PR TITLE
Fix explorer call on Windows to work with spaces in filepaths.

### DIFF
--- a/jupyterlab-fileopen/handlers.py
+++ b/jupyterlab-fileopen/handlers.py
@@ -52,7 +52,7 @@ class FileExplorerHandler(BaseHandler):
                 command = os.path.join(os.environ["SystemRoot"], 'explorer.exe')
             else:
                 command = "explorer.exe"
-            subprocess.run([command, f"/select,{path}"])
+            subprocess.run(f"{command} /select,{path}", shell=True)
 
         self.finish(json.dumps({
             "success": True


### PR DESCRIPTION
Hy,

Thank you for this great extension that I use very often.

On my Windows machine I have problems to open a file in explorer that contains spaces in its filename.
After a call the User's Documents folder is shown in the explorer instead of the chosen file.

This small bug fix changes the subprocess.run command from a list to a single string.
In the original call the filepath contains double backslashes. With this change the command is called with a filepath that has only single backslashes.

Greets,
Martin